### PR TITLE
chore: update test nodejs versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [22, 20, 18, 16, 14]
+        version: [24, 22, 20]
         os: [windows-latest, macos-latest-large, ubuntu-latest]
     name: Node ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This pr updates the nodejs test version matrix.

14, 16 are no longer supported.
18 will very soon be no longer supported.


https://nodejs.org/en/about/previous-releases 
![schedule](https://github.com/user-attachments/assets/07372282-307b-47ad-a3e6-09f47d309965)
