### PR TITLE
added security alerts

### DIFF
--- a/.github/workflows/push_dependabot_metadata.yml
+++ b/.github/workflows/push_dependabot_metadata.yml
@@ -1,0 +1,18 @@
+name: Send data to Security Alerts
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 10 * * *'
+
+jobs:
+  send-alerts:
+    runs-on: sfdc-hk-ubuntu-latest
+    steps:
+      - name: Send data to Security Alerts
+        uses: heroku/security-alerts-action@stable
+        with:
+          gh-app-id: ${{ secrets.SECURITY_ALERTS_GH_APP_ID }}
+          gh-app-privkey: ${{ secrets.SECURITY_ALERTS_GH_APP_PRIVKEY }}
+          webhook-url: ${{ secrets.SECURITY_ALERTS_WEBHOOK_URL }}
+          sa-token: ${{ secrets.SECURITY_ALERTS_TOKEN }}


### PR DESCRIPTION
This PR will enroll heroku-applink-nodejs into security-alerts using [these instructions](https://github.com/heroku/security-alerts/blob/bb42ce074f3ad9587ef55c8b63031a23f538cf22/docs/getting_started.md?plain=1#L8)