### PR TITLE
add dry-run, npm tags to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,6 @@ You will need java installed to run wiremock.
 
 ### Running tests
 To test with coverage run `yarn test:coverage`
+
+## Publishing
+`yarn release` will release the current version. `yarn release:dry-run` can be used to dry-run a release. The npm distribution tag is based on the pre-release semver suffix (1.0.0-ea would) release with the tag `ea`. If no pre-release suffix exists, releases are published with the `latest` tag.

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -1,9 +1,49 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Running npm publish..."
-npm publish
+# Default values
+dry_run=false
 
-echo "Creating git tag..."
-git tag "v${version}"
-git push --tags
+usage() {
+  echo "Usage: $0 [-d] [-h]"
+  echo "  -d    Perform a dry run without actually publishing or creating git tags"
+  echo "  -h    Show this help message"
+  exit 1
+}
+
+while getopts ":dh" opt; do
+  case $opt in
+    d)
+      dry_run=true
+      ;;
+    h)
+      usage
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG"
+      usage
+      ;;
+  esac
+done
+
+version=$(node -p "require('./package.json').version")
+if [[ $version == *-* ]]; then
+  # Extract suffix after the last dash (e.g., "1.0.0-ea" -> "ea")
+  tag="${version##*-}"
+else
+  # No suffix, use latest tag
+  tag="latest"
+fi
+
+if [[ "$dry_run" == true ]]; then
+  npm publish --tag "$tag" --dry-run
+
+  echo "DRY RUN: Skipping git tag and push operations"
+else
+  echo "Publishing version $version with tag '$tag'..."
+  npm publish --tag "$tag"
+
+  echo "Creating git tag..."
+  git tag "v${version}"
+  git push --tags
+fi

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepack": "tsc -b --clean && tsc -b --force",
     "bump": "node bin/bump-version.js",
     "release": "bin/publish.sh",
+    "release:dry-run": "bin/publish.sh -d",
     "docs": "typedoc"
   },
   "files": [


### PR DESCRIPTION
## Description

This pr updates the publish command to support npm distribution tags based on the semver pre-release suffix defined in package.json's version field.

Additionally, we introduce dry run capabilities to publish.sh.

## Testing

I tested the dry-run feature. Will test an actual release when we release.

*0.3.4-ea*
```
% yarn release:dry-run
yarn run v1.22.22
$ bin/publish.sh -d

> @heroku/salesforce-sdk-nodejs@0.3.4-ea prepack
> tsc -b --clean && tsc -b --force

npm notice
npm notice 📦  @heroku/salesforce-sdk-nodejs@0.3.4-ea
npm notice Tarball Contents
npm notice 667B CHANGELOG.md
...
npm notice 2.5kB package.json
npm notice Tarball Details
npm notice name: @heroku/salesforce-sdk-nodejs
npm notice version: 0.3.4-ea
npm notice filename: heroku-salesforce-sdk-nodejs-0.3.4-ea.tgz
npm notice package size: 19.4 kB
npm notice unpacked size: 73.6 kB
npm notice shasum: ae7b7299f69dbb819c3dd853d24385721b1c20d4
npm notice integrity: sha512-OiHcdzCg5YAAL[...]D7nlugK4LKKQg==
npm notice total files: 40
npm notice
npm warn This command requires you to be logged in to https://registry.yarnpkg.com (dry-run)
npm notice Publishing to https://registry.yarnpkg.com with tag ea and default access (dry-run)
+ @heroku/salesforce-sdk-nodejs@0.3.4-ea
DRY RUN: Skipping git tag and push operations
✨  Done in 4.50s.
```

*0.3.4*
```
% yarn release:dry-run
yarn run v1.22.22
$ bin/publish.sh -d

> @heroku/salesforce-sdk-nodejs@0.3.4 prepack
> tsc -b --clean && tsc -b --force

npm notice
npm notice 📦  @heroku/salesforce-sdk-nodejs@0.3.4
npm notice Tarball Contents
npm notice 667B CHANGELOG.md
...
npm notice 2.5kB package.json
npm notice Tarball Details
npm notice name: @heroku/salesforce-sdk-nodejs
npm notice version: 0.3.4
npm notice filename: heroku-salesforce-sdk-nodejs-0.3.4.tgz
npm notice package size: 19.4 kB
npm notice unpacked size: 73.6 kB
npm notice shasum: 842cb6cd784c0941a668737b78a40bfc16d33a4a
npm notice integrity: sha512-RRFHfP8sJexO0[...]EjNJNyMcksrdQ==
npm notice total files: 40
npm notice
npm warn This command requires you to be logged in to https://registry.yarnpkg.com (dry-run)
npm notice Publishing to https://registry.yarnpkg.com with tag latest and default access (dry-run)
+ @heroku/salesforce-sdk-nodejs@0.3.4
DRY RUN: Skipping git tag and push operations
✨  Done in 3.97s.
```
