### PR TITLE
add x-request-id default header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Update `HttpRequestUtil.request` documentation
 - Update license year
+- Add `X-Request-Id` header

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { randomUUID } from 'node:crypto';
+import { randomUUID } from "node:crypto";
 
 /** Error thrown by the SDK when receiving non-2xx responses on HTTP requests. */
 export class HTTPResponseError extends Error {
@@ -20,7 +20,7 @@ export class HTTPResponseError extends Error {
  * UUID generator utility wrapping node:crypto's randomUUID for stubbing in tests
  */
 export const uuidGenerator = {
-  generate: () => randomUUID()
+  generate: () => randomUUID(),
 };
 
 /**

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { randomUUID } from 'node:crypto';
+
 /** Error thrown by the SDK when receiving non-2xx responses on HTTP requests. */
 export class HTTPResponseError extends Error {
   response: any;
@@ -15,6 +17,13 @@ export class HTTPResponseError extends Error {
 }
 
 /**
+ * UUID generator utility wrapping node:crypto's randomUUID for stubbing in tests
+ */
+export const uuidGenerator = {
+  generate: () => randomUUID()
+};
+
+/**
  * Handles HTTP requests.
  */
 export class HttpRequestUtil {
@@ -23,7 +32,7 @@ export class HttpRequestUtil {
    * 
    * @param url - The URL to make the request to
    * @param opts - Fetch request options (method, headers, body, etc.). Headers will be merged 
-   *               with default headers `{ "User-Agent: heroku-applink-node-sdk/1.0" }`
+   *               with default User-Agent and X-Request-ID headers.
 
    * @param json - Whether to parse the response as JSON (default: true). If false, 
    *               returns the raw Response object
@@ -36,6 +45,7 @@ export class HttpRequestUtil {
       ...opts,
       headers: {
         "User-Agent": "heroku-applink-node-sdk/1.0",
+        "X-Request-Id": uuidGenerator.generate(),
         ...(opts?.headers ?? {}),
       },
     };

--- a/test/utils/request.test.ts
+++ b/test/utils/request.test.ts
@@ -7,7 +7,11 @@
 
 import { expect } from "chai";
 import sinon from "sinon";
-import { HttpRequestUtil, HTTPResponseError, uuidGenerator } from "../../src/utils/request";
+import {
+  HttpRequestUtil,
+  HTTPResponseError,
+  uuidGenerator,
+} from "../../src/utils/request";
 
 describe("HttpRequestUtil", () => {
   let httpRequestUtil: HttpRequestUtil;
@@ -96,7 +100,7 @@ describe("HttpRequestUtil", () => {
     it("should include default request-id header", async () => {
       const mockUUID = "test-uuid-1234-5678-9abc";
       uuidGeneratorStub.returns(mockUUID);
-      
+
       const mockResponse = {
         ok: true,
         status: 200,
@@ -117,7 +121,7 @@ describe("HttpRequestUtil", () => {
       const mockUUID2 = "test-uuid-2222-2222-2222";
       uuidGeneratorStub.onFirstCall().returns(mockUUID1);
       uuidGeneratorStub.onSecondCall().returns(mockUUID2);
-      
+
       const mockResponse = {
         ok: true,
         status: 200,
@@ -131,7 +135,7 @@ describe("HttpRequestUtil", () => {
 
       const [, options1] = fetchStub.getCall(0).args;
       const [, options2] = fetchStub.getCall(1).args;
-      
+
       expect(options1.headers["X-Request-Id"]).to.equal(mockUUID1);
       expect(options2.headers["X-Request-Id"]).to.equal(mockUUID2);
       expect(uuidGeneratorStub.calledTwice).to.be.true;
@@ -140,7 +144,7 @@ describe("HttpRequestUtil", () => {
     it("should merge custom headers with default headers", async () => {
       const mockUUID = "test-uuid-merge-test";
       uuidGeneratorStub.returns(mockUUID);
-      
+
       const mockResponse = {
         ok: true,
         status: 200,
@@ -172,7 +176,7 @@ describe("HttpRequestUtil", () => {
     it("should allow custom headers to override User-Agent", async () => {
       const mockUUID = "test-uuid-override-test";
       uuidGeneratorStub.returns(mockUUID);
-      
+
       const mockResponse = {
         ok: true,
         status: 200,
@@ -197,7 +201,7 @@ describe("HttpRequestUtil", () => {
     it("should allow custom headers to override request-id", async () => {
       // UUID generator should still be called since it's called before merging custom headers
       uuidGeneratorStub.returns("generated-uuid-that-gets-overridden");
-      
+
       const mockResponse = {
         ok: true,
         status: 200,
@@ -217,7 +221,9 @@ describe("HttpRequestUtil", () => {
 
       const [, options] = fetchStub.getCall(0).args;
       expect(options.headers["X-Request-Id"]).to.equal(customRequestId);
-      expect(options.headers["User-Agent"]).to.equal("heroku-applink-node-sdk/1.0");
+      expect(options.headers["User-Agent"]).to.equal(
+        "heroku-applink-node-sdk/1.0"
+      );
       // UUID generator should still be called since it's called before merging custom headers
       expect(uuidGeneratorStub.calledOnce).to.be.true;
     });


### PR DESCRIPTION
## Description

This pr adds a default `X-Request-Id` header to http requests fired by the sdk

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002FsI8YYAV/view

## Testing
Added ci tests to cover the new code.