### PR TITLE
update runners for public repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         version: [22.x, 20.x, 18.x]
         os:
-          [sfdc-hk-ubuntu-latest, sfdc-hk-macos-latest, sfdc-hk-windows-latest]
+          [ubuntu-latest, macos-latest, windows-latest]
     name: Node ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [22.x, 20.x, 18.x]
-        os:
-          [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     name: Node ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-changelog:
-    runs-on: sfdc-hk-ubuntu-latest # TODO: change to ubuntu-latest when public
+    runs-on: ubuntu-latest
     if: |
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&


### PR DESCRIPTION
## Description

Now that this repository is public, we switch to using public runners per https://salesforce.quip.com/bu6UA0KImOxJ