### PR TITLE
increase java heap memory during tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [22.x, 20.x, 18.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-14-large, windows-latest]
     name: Node ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `X-Request-Id` header
 - Extract `User-Agent` header from package.json
 - Rename `HTTPResponseError` -> `HttpResponseError`
+- Fix Java heap memory test issue

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b",
     "lint": "eslint . --ext .ts --max-warnings 0 --report-unused-disable-directives --format codeframe",
     "lint:fix": "npm run lint -- --fix",
-    "wiremock": "JAVA_OPTS='-Xmx1024m -Xms512m' wiremock --port 8080 --bind-address 127.0.0.1 --disable-banner",
+    "wiremock": "JAVA_OPTS='-Xmx1536m -Xms768m' wiremock --port 8080 --bind-address 127.0.0.1 --disable-banner --disable-request-logging --no-request-journal",
     "mocha": "mocha",
     "test": "cross-env NODE_ENV=test TS_NODE_PROJECT=tsconfig.test.json concurrently -k -s first \"wiremock\" \"mocha\"",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",


### PR DESCRIPTION
There is currently a test that has been flaky during the build workflow in github. It will fail with the underlying reason being wiremock running out of heap memory:
```
java.lang.OutOfMemoryError: Java heap space
```

This test will typically pass when you re-run this specific job on its own. The current fix is to increase the macos job runner to macos-14-large and increase heap memory for the Java environment. Tests running in these jobs have yet to fail while running simultaneously.

The purpose of this specific test is to generate a large test dataset that would be returned by salesforce and to handle that payload accordingly. 
