### PR TITLE
extract user agent from package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `HttpRequestUtil.request` documentation
 - Update license year
 - Add `X-Request-Id` header
-- Add `User-Agent` header extracted from package.json
+- Extract `User-Agent` header from package.json
 - Rename `HTTPResponseError` -> `HttpResponseError`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `HttpRequestUtil.request` documentation
 - Update license year
 - Add `X-Request-Id` header
+- Add `User-Agent` header extracted from package.json
+- Rename `HTTPResponseError` -> `HttpResponseError`

--- a/src/add-ons/heroku-applink.ts
+++ b/src/add-ons/heroku-applink.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { HttpRequestUtil, HTTPResponseError } from "../utils/request";
+import { HttpRequestUtil, HttpResponseError } from "../utils/request";
 import { OrgImpl } from "../sdk/org";
 import { Org } from "../index";
 import {
@@ -59,7 +59,7 @@ export async function getAuthorization(
   try {
     response = await HTTP_REQUEST.request(authUrl, opts);
   } catch (err) {
-    if (err instanceof HTTPResponseError) {
+    if (err instanceof HttpResponseError) {
       let errorResponse;
       try {
         errorResponse = await err.response.json();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { InvocationEventImpl } from "./sdk/invocation-event.js";
 import { LoggerImpl } from "./sdk/logger.js";
 import { QueryOperation } from "jsforce/lib/api/bulk";
 import { getAuthorization } from "./add-ons/heroku-applink.js";
-import { HTTPResponseError } from "./utils/request.js";
+import { HttpResponseError } from "./utils/request.js";
 
 const CONTENT_TYPE_HEADER = "Content-Type";
 const X_CLIENT_CONTEXT_HEADER = "x-client-context";
@@ -106,7 +106,7 @@ export function parseDataActionEvent(payload: any): DataCloudActionEvent {
   return payload as DataCloudActionEvent;
 }
 
-export { HTTPResponseError };
+export { HttpResponseError };
 
 //  T Y P E S
 

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -21,7 +21,7 @@ function getUserAgent(): string {
 }
 
 /** Error thrown by the SDK when receiving non-2xx responses on HTTP requests. */
-export class HTTPResponseError extends Error {
+export class HttpResponseError extends Error {
   response: any;
   constructor(response: Response) {
     super(`HTTP Error Response: ${response.status}: ${response.statusText}`);
@@ -51,7 +51,7 @@ export class HttpRequestUtil {
    *               returns the raw Response object
    * @returns Promise that resolves to the parsed JSON response (if json=true) or 
    *          the raw Response object (if json=false)
-   * @throws {HTTPResponseError} When the response status is not in the 2xx range
+   * @throws {HttpResponseError} When the response status is not in the 2xx range
    */
   async request(url: string, opts: any, json = true) {
     const mergedOpts = {
@@ -66,7 +66,7 @@ export class HttpRequestUtil {
     const response = await fetch(url, mergedOpts);
 
     if (!response.ok) {
-      throw new HTTPResponseError(response);
+      throw new HttpResponseError(response);
     }
 
     return json ? response.json() : response;

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -6,6 +6,19 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+let cachedUserAgent: string;
+
+function getUserAgent(): string {
+  if (cachedUserAgent === null) {
+    const packageJsonPath = join(__dirname, "..", "..", "package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    cachedUserAgent = `${packageJson.name}/${packageJson.version}`;
+  }
+  return cachedUserAgent;
+}
 
 /** Error thrown by the SDK when receiving non-2xx responses on HTTP requests. */
 export class HTTPResponseError extends Error {
@@ -44,7 +57,7 @@ export class HttpRequestUtil {
     const mergedOpts = {
       ...opts,
       headers: {
-        "User-Agent": "heroku-applink-node-sdk/1.0",
+        "User-Agent": getUserAgent(),
         "X-Request-Id": uuidGenerator.generate(),
         ...(opts?.headers ?? {}),
       },

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -6,19 +6,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
-let cachedUserAgent: string;
-
-function getUserAgent(): string {
-  if (cachedUserAgent === null) {
-    const packageJsonPath = join(__dirname, "..", "..", "package.json");
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
-    cachedUserAgent = `${packageJson.name}/${packageJson.version}`;
-  }
-  return cachedUserAgent;
-}
+import packageJson from "../../package.json";
 
 /** Error thrown by the SDK when receiving non-2xx responses on HTTP requests. */
 export class HttpResponseError extends Error {
@@ -42,14 +30,13 @@ export const uuidGenerator = {
 export class HttpRequestUtil {
   /**
    * Makes an HTTP request
-   * 
+   *
    * @param url - The URL to make the request to
-   * @param opts - Fetch request options (method, headers, body, etc.). Headers will be merged 
+   * @param opts - Fetch request options (method, headers, body, etc.). Headers will be merged
    *               with default User-Agent and X-Request-ID headers.
-
-   * @param json - Whether to parse the response as JSON (default: true). If false, 
+   * @param json - Whether to parse the response as JSON (default: true). If false,
    *               returns the raw Response object
-   * @returns Promise that resolves to the parsed JSON response (if json=true) or 
+   * @returns Promise that resolves to the parsed JSON response (if json=true) or
    *          the raw Response object (if json=false)
    * @throws {HttpResponseError} When the response status is not in the 2xx range
    */
@@ -57,7 +44,7 @@ export class HttpRequestUtil {
     const mergedOpts = {
       ...opts,
       headers: {
-        "User-Agent": getUserAgent(),
+        "User-Agent": `${packageJson.name}/${packageJson.version}`,
         "X-Request-Id": uuidGenerator.generate(),
         ...(opts?.headers ?? {}),
       },

--- a/test/add-ons/heroku-applink.test.ts
+++ b/test/add-ons/heroku-applink.test.ts
@@ -7,7 +7,7 @@
 
 import { expect } from "chai";
 import sinon from "sinon";
-import { HttpRequestUtil, HTTPResponseError } from "../../src/utils/request";
+import { HttpRequestUtil, HttpResponseError } from "../../src/utils/request";
 import { getAuthorization } from "../../src/add-ons/heroku-applink";
 import { OrgImpl } from "../../src/sdk/org";
 
@@ -118,7 +118,7 @@ describe("getAuthorization", () => {
       }),
       { status: 404 }
     );
-    httpRequestStub.rejects(new HTTPResponseError(errorResponse));
+    httpRequestStub.rejects(new HttpResponseError(errorResponse));
 
     try {
       await getAuthorization("testDev");
@@ -132,7 +132,7 @@ describe("getAuthorization", () => {
     const invalidJsonResponse = new Response("Invalid JSON content", {
       status: 500,
     });
-    httpRequestStub.rejects(new HTTPResponseError(invalidJsonResponse));
+    httpRequestStub.rejects(new HttpResponseError(invalidJsonResponse));
 
     try {
       await getAuthorization("testDev");

--- a/test/utils/request.test.ts
+++ b/test/utils/request.test.ts
@@ -10,7 +10,7 @@ import sinon from "sinon";
 import * as fs from "node:fs";
 import {
   HttpRequestUtil,
-  HTTPResponseError,
+  HttpResponseError,
   uuidGenerator,
 } from "../../src/utils/request";
 
@@ -257,7 +257,7 @@ describe("HttpRequestUtil", () => {
       expect(uuidGeneratorStub.calledOnce).to.be.true;
     });
 
-    it("should throw HTTPResponseError for 4xx status codes", async () => {
+    it("should throw HttpResponseError for 4xx status codes", async () => {
       const mockResponse = {
         ok: false,
         status: 404,
@@ -267,15 +267,15 @@ describe("HttpRequestUtil", () => {
 
       try {
         await httpRequestUtil.request("https://api.example.com/test", {});
-        expect.fail("Should have thrown HTTPResponseError");
+        expect.fail("Should have thrown HttpResponseError");
       } catch (error) {
-        expect(error).to.be.instanceOf(HTTPResponseError);
+        expect(error).to.be.instanceOf(HttpResponseError);
         expect(error.message).to.equal("HTTP Error Response: 404: Not Found");
         expect(error.response).to.equal(mockResponse);
       }
     });
 
-    it("should throw HTTPResponseError for 5xx status codes", async () => {
+    it("should throw HttpResponseError for 5xx status codes", async () => {
       const mockResponse = {
         ok: false,
         status: 500,
@@ -285,9 +285,9 @@ describe("HttpRequestUtil", () => {
 
       try {
         await httpRequestUtil.request("https://api.example.com/test", {});
-        expect.fail("Should have thrown HTTPResponseError");
+        expect.fail("Should have thrown HttpResponseError");
       } catch (error) {
-        expect(error).to.be.instanceOf(HTTPResponseError);
+        expect(error).to.be.instanceOf(HttpResponseError);
         expect(error.message).to.equal(
           "HTTP Error Response: 500: Internal Server Error"
         );
@@ -307,14 +307,14 @@ describe("HttpRequestUtil", () => {
     });
   });
 
-  describe("HTTPResponseError", () => {
+  describe("HttpResponseError", () => {
     it("should create error with correct message and response", () => {
       const mockResponse = {
         status: 403,
         statusText: "Forbidden",
       } as Response;
 
-      const error = new HTTPResponseError(mockResponse);
+      const error = new HttpResponseError(mockResponse);
 
       expect(error.message).to.equal("HTTP Error Response: 403: Forbidden");
       expect(error.response).to.equal(mockResponse);
@@ -327,7 +327,7 @@ describe("HttpRequestUtil", () => {
         statusText: "",
       } as Response;
 
-      const error = new HTTPResponseError(mockResponse);
+      const error = new HttpResponseError(mockResponse);
 
       expect(error.message).to.equal("HTTP Error Response: 422: ");
       expect(error.response).to.equal(mockResponse);

--- a/test/utils/request.test.ts
+++ b/test/utils/request.test.ts
@@ -7,7 +7,7 @@
 
 import { expect } from "chai";
 import sinon from "sinon";
-import * as fs from "node:fs";
+import packageJson from "../../package.json";
 import {
   HttpRequestUtil,
   HttpResponseError,
@@ -18,18 +18,11 @@ describe("HttpRequestUtil", () => {
   let httpRequestUtil: HttpRequestUtil;
   let fetchStub: sinon.SinonStub;
   let uuidGeneratorStub: sinon.SinonStub;
-  let readFileSyncStub: sinon.SinonStub;
 
   beforeEach(() => {
     httpRequestUtil = new HttpRequestUtil();
     fetchStub = sinon.stub(global, "fetch");
     uuidGeneratorStub = sinon.stub(uuidGenerator, "generate");
-    readFileSyncStub = sinon.stub(fs, "readFileSync");
-    
-    readFileSyncStub.returns(JSON.stringify({
-      name: "@heroku/applink",
-      version: "1.0.0-ea.1"
-    }));
   });
 
   afterEach(() => {
@@ -61,7 +54,7 @@ describe("HttpRequestUtil", () => {
       expect(url).to.equal("https://api.example.com/test");
       expect(options.method).to.equal("GET");
       expect(options.headers["User-Agent"]).to.equal(
-        "@heroku/applink/1.0.0-ea.1"
+        `${packageJson.name}/${packageJson.version}`
       );
     });
 
@@ -101,28 +94,8 @@ describe("HttpRequestUtil", () => {
 
       const [, options] = fetchStub.getCall(0).args;
       expect(options.headers["User-Agent"]).to.equal(
-        "@heroku/applink/1.0.0-ea.1"
+        `${packageJson.name}/${packageJson.version}`
       );
-    });
-
-    it("should cache User-Agent and only read package.json once", async () => {
-      const mockResponse = {
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        json: sinon.stub().resolves({}),
-      };
-      fetchStub.resolves(mockResponse);
-
-      await httpRequestUtil.request("https://api.example.com/test1", {});
-      await httpRequestUtil.request("https://api.example.com/test2", {});
-
-      const [, options1] = fetchStub.getCall(0).args;
-      const [, options2] = fetchStub.getCall(1).args;
-      
-      expect(readFileSyncStub.calledOnce).to.be.true;
-      expect(options1.headers["User-Agent"]).to.equal("@heroku/applink/1.0.0-ea.1");
-      expect(options2.headers["User-Agent"]).to.equal("@heroku/applink/1.0.0-ea.1");
     });
 
     it("should include default request-id header", async () => {
@@ -194,7 +167,7 @@ describe("HttpRequestUtil", () => {
       const [, options] = fetchStub.getCall(0).args;
       expect(options.method).to.equal("POST");
       expect(options.headers["User-Agent"]).to.equal(
-        "@heroku/applink/1.0.0-ea.1"
+        `${packageJson.name}/${packageJson.version}`
       );
       expect(options.headers["X-Request-Id"]).to.equal(mockUUID);
       expect(options.headers["Content-Type"]).to.equal("application/json");
@@ -250,7 +223,7 @@ describe("HttpRequestUtil", () => {
       const [, options] = fetchStub.getCall(0).args;
       expect(options.headers["X-Request-Id"]).to.equal(customRequestId);
       expect(options.headers["User-Agent"]).to.equal(
-        "@heroku/applink/1.0.0-ea.1"
+        `${packageJson.name}/${packageJson.version}`
       );
       // UUID generator should still be called since it's called before merging custom headers
       expect(uuidGeneratorStub.calledOnce).to.be.true;

--- a/test/utils/request.test.ts
+++ b/test/utils/request.test.ts
@@ -114,7 +114,6 @@ describe("HttpRequestUtil", () => {
       };
       fetchStub.resolves(mockResponse);
 
-      // Make multiple requests
       await httpRequestUtil.request("https://api.example.com/test1", {});
       await httpRequestUtil.request("https://api.example.com/test2", {});
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "pretty": true,
     "removeComments": true,
     "declaration": true,
+    "resolveJsonModule": true,
     "paths": {
       "~/*": ["./src/*"]
     }


### PR DESCRIPTION
## Description

This pr updates the node sdk to extract the `User-Agent` header from `package.json` to simplify version bumps.

Additionally, we update `HTTPResponseError` -> `HttpResponseError` to align with `HttpRequestUtil` capitalization.

Both nice-to-haves for GA.


## Testing 

CI Tests