### PR TITLE
pass data cloud query as body

### DIFF
--- a/src/sdk/data-cloud-api.ts
+++ b/src/sdk/data-cloud-api.ts
@@ -35,7 +35,7 @@ export class DataCloudApiImpl implements DataCloudApi {
       retry: {
         limit: 1,
       },
-      json: sql,
+      body: JSON.stringify({ sql }),
     };
     const response = await this.request.request(url, opts);
     return response as DataCloudQueryResponse;

--- a/src/sdk/data-cloud-api.ts
+++ b/src/sdk/data-cloud-api.ts
@@ -72,7 +72,7 @@ export class DataCloudApiImpl implements DataCloudApi {
       retry: {
         limit: 1,
       },
-      json: data,
+      body: JSON.stringify(data),
     };
     const response = await this.request.request(url, opts);
     return response as DataCloudUpsertResponse;


### PR DESCRIPTION
# Pull Request

## Summary

The request format was incorrect for the body for data-cloud-api, this PR updates that.


Fixes call to https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/data-cloud-query-api-reference/c360a-api-query-v2.html

---

## What Changed

Fixes data-cloud-api call

---

## Checklist


- [ ] I’ve added or updated unit tests where necessary
- [ ] I’ve added or updated documentation
- [ ] I've run `yarn docs` to generate the documentation
- [ ] I’ve manually tested the functionality in this PR
- [ ] This pull request is ready for review

---

## Testing

<!--
Explain how you tested your changes. Include commands, env details, or Heroku resources if needed.
-->