### PR TITLE
Fix commitUnitOfWork to surface all errors using Promise.allSettled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,4 +60,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release New Latest Version Based off of beta release 1.1.0-beta.1
 
 ## [Unreleased]
-- Fix `commitUnitOfWork` to surface all subrequest errors using `Promise.allSettled`; previously `Promise.all` short-circuited on the first rejection and discarded subsequent errors
+- Fix `commitUnitOfWork` to surface all subrequest errors. Previously, when multiple subrequests failed, `commitUnitOfWork` only surfaced the first error and discarded subsequent errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.0] - 2026-02-26
 - Release New Latest Version Based off of beta release 1.1.0-beta.1
+
+## [Unreleased]
+- Fix `commitUnitOfWork` to surface all subrequest errors using `Promise.allSettled`; previously `Promise.all` short-circuited on the first rejection and discarded subsequent errors

--- a/mappings/composite-graph-create-account-contact-opportunity.json
+++ b/mappings/composite-graph-create-account-contact-opportunity.json
@@ -1,0 +1,28 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "name": "services_data_v510_composite_graph_account_contact_opportunity",
+  "request": {
+    "url": "/services/data/v51.0/composite/graph",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"graphs\": [\n        {\n            \"graphId\": \"graph0\",\n            \"compositeRequest\": [\n                {\n                    \"url\": \"/services/data/v51.0/sobjects/Account\",\n                    \"method\": \"POST\",\n                    \"referenceId\": \"reference_id_account_1\",\n                    \"body\": {\n                        \"Name\": \"Acme Corp\"\n                    }\n                },\n                {\n                    \"url\": \"/services/data/v51.0/sobjects/Contact\",\n                    \"method\": \"POST\",\n                    \"referenceId\": \"reference_id_contact_1\",\n                    \"body\": {\n                        \"LastName\": \"Smith\"\n                    }\n                },\n                {\n                    \"url\": \"/services/data/v51.0/sobjects/Opportunity\",\n                    \"method\": \"POST\",\n                    \"referenceId\": \"reference_id_opportunity_1\",\n                    \"body\": {\n                        \"Name\": \"Big Deal\",\n                        \"StageName\": \"Prospecting\",\n                        \"CloseDate\": \"2024-01-01\"\n                    }\n                }\n            ]\n        }\n    ]\n}"
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer EXAMPLE-TOKEN"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"graphs\":[{\"graphId\":\"1\",\"graphResponse\":{\"compositeResponse\":[{\"body\":{\"id\":\"001R00000064wc7IAA\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v66.0/sobjects/Account/001R00000064wc7IAA\"},\"httpStatusCode\":201,\"referenceId\":\"reference_id_account_1\"},{\"body\":{\"id\":\"003R000000DDMlTIAX\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v66.0/sobjects/Contact/003R000000DDMlTIAX\"},\"httpStatusCode\":201,\"referenceId\":\"reference_id_contact_1\"},{\"body\":{\"id\":\"006R0000003FPYxIAO\",\"success\":true,\"errors\":[]},\"httpHeaders\":{\"Location\":\"/services/data/v66.0/sobjects/Opportunity/006R0000003FPYxIAO\"},\"httpStatusCode\":201,\"referenceId\":\"reference_id_opportunity_1\"}]},\"isSuccessful\":true}]}",
+    "headers": {
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "persistent": true,
+  "insertionIndex": 4
+}

--- a/mappings/composite-graph-multiple-errors.json
+++ b/mappings/composite-graph-multiple-errors.json
@@ -1,0 +1,28 @@
+{
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "name": "services_data_v510_composite_graph_multiple_errors",
+  "request": {
+    "url": "/services/data/v51.0/composite/graph",
+    "method": "POST",
+    "bodyPatterns": [
+      {
+        "equalToJson": "{\n    \"graphs\": [\n        {\n            \"graphId\": \"graph0\",\n            \"compositeRequest\": [\n                {\n                    \"url\": \"/services/data/v51.0/sobjects/Account\",\n                    \"method\": \"POST\",\n                    \"referenceId\": \"referenceId0\",\n                    \"body\": {\n                        \"Name\": \"Acme Corp\"\n                    }\n                },\n                {\n                    \"url\": \"/services/data/v51.0/sobjects/Contact\",\n                    \"method\": \"POST\",\n                    \"referenceId\": \"referenceId1\",\n                    \"body\": {\n                        \"LastName\": \"Smith\"\n                    }\n                }\n            ]\n        }\n    ]\n}"
+      }
+    ],
+    "headers": {
+      "Authorization": {
+        "equalTo": "Bearer EXAMPLE-TOKEN"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "{\"graphs\":[{\"graphId\":\"graph0\",\"graphResponse\":{\"compositeResponse\":[{\"body\":[{\"errorCode\":\"PROCESSING_HALTED\",\"message\":\"The transaction was rolled back since another operation in the same transaction failed\"}],\"httpHeaders\":{},\"httpStatusCode\":400,\"referenceId\":\"referenceId0\"},{\"body\":[{\"errorCode\":\"INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY\",\"message\":\"insufficient access rights on cross-reference id. You can't complete this action because you don't have the required access\"}],\"httpHeaders\":{},\"httpStatusCode\":403,\"referenceId\":\"referenceId1\"}]},\"isSuccessful\":false}]}",
+    "headers": {
+      "Content-Type": "application/json;charset=UTF-8"
+    }
+  },
+  "uuid": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "persistent": true,
+  "insertionIndex": 5
+}

--- a/mappings/composite-graph-multiple-errors.json
+++ b/mappings/composite-graph-multiple-errors.json
@@ -17,7 +17,7 @@
   },
   "response": {
     "status": 200,
-    "body": "{\"graphs\":[{\"graphId\":\"graph0\",\"graphResponse\":{\"compositeResponse\":[{\"body\":[{\"errorCode\":\"PROCESSING_HALTED\",\"message\":\"The transaction was rolled back since another operation in the same transaction failed\"}],\"httpHeaders\":{},\"httpStatusCode\":400,\"referenceId\":\"referenceId0\"},{\"body\":[{\"errorCode\":\"INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY\",\"message\":\"insufficient access rights on cross-reference id. You can't complete this action because you don't have the required access\"}],\"httpHeaders\":{},\"httpStatusCode\":403,\"referenceId\":\"referenceId1\"}]},\"isSuccessful\":false}]}",
+    "body": "{\"graphs\":[{\"graphId\":\"graph0\",\"graphResponse\":{\"compositeResponse\":[{\"body\":[{\"errorCode\":\"PROCESSING_HALTED\",\"message\":\"We rolled back the transaction since another operation in the same transaction failed.\"}],\"httpHeaders\":{},\"httpStatusCode\":400,\"referenceId\":\"referenceId0\"},{\"body\":[{\"errorCode\":\"INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY\",\"message\":\"You can’t complete this action because you don’t have the required access on the cross-reference ID. Contact your Salesforce admin to gain access.\"}],\"httpHeaders\":{},\"httpStatusCode\":403,\"referenceId\":\"referenceId1\"}]},\"isSuccessful\":false}]}",
     "headers": {
       "Content-Type": "application/json;charset=UTF-8"
     }

--- a/src/sdk/data-api.ts
+++ b/src/sdk/data-api.ts
@@ -201,9 +201,7 @@ export class DataApiImpl implements DataApi {
         );
       }
 
-      const subrequestResults: Promise<
-        [ReferenceId, RecordModificationResult][]
-      > = Promise.all(
+      const settled = await Promise.allSettled(
         requestResult.graphs[0].graphResponse.compositeResponse.map(
           (compositeResponse) => {
             const subrequest = subrequests.find(
@@ -225,7 +223,18 @@ export class DataApiImpl implements DataApi {
         )
       );
 
-      return subrequestResults.then((keyValues) => new Map(keyValues));
+      const failures = settled.filter((r) => r.status === "rejected");
+      if (failures.length > 0) {
+        throw new Error(
+          failures
+            .map((r) => (r as PromiseRejectedResult).reason.message)
+            .join("\n")
+        );
+      }
+
+      return new Map(
+        settled.map((r) => (r as PromiseFulfilledResult<any>).value)
+      );
     });
   }
 

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -736,6 +736,76 @@ describe("DataApi Class", async () => {
           expect(result.size).to.equal(0);
         });
       });
+
+      describe("docs example: account, contact, and opportunity", async () => {
+        beforeEach(() => {
+          const genRefId = stub(uow, "generateReferenceId");
+          genRefId.onFirstCall().returns("reference_id_account_1");
+          genRefId.onSecondCall().returns("reference_id_contact_1");
+          genRefId.onThirdCall().returns("reference_id_opportunity_1");
+        });
+
+        it("returns all record ids on success", async () => {
+          const accountRId = uow.registerCreate({
+            type: "Account",
+            fields: {
+              Name: "Acme Corp",
+            },
+          });
+
+          const contactRId = uow.registerCreate({
+            type: "Contact",
+            fields: {
+              LastName: "Smith",
+            },
+          });
+
+          const opportunityRId = uow.registerCreate({
+            type: "Opportunity",
+            fields: {
+              Name: "Big Deal",
+              StageName: "Prospecting",
+              CloseDate: "2024-01-01",
+            },
+          });
+
+          const result = await dataApiv51.commitUnitOfWork(uow);
+          expect(result.size).equal(3);
+          expect(result.get(accountRId).id).equal("001R00000064wc7IAA");
+          expect(result.get(contactRId).id).equal("003R000000DDMlTIAX");
+          expect(result.get(opportunityRId).id).equal("006R0000003FPYxIAO");
+        });
+      });
+
+      describe("multiple errors", async () => {
+        it("throws an error containing all error messages", async () => {
+          uow.registerCreate({
+            type: "Account",
+            fields: {
+              Name: "Acme Corp",
+            },
+          });
+
+          uow.registerCreate({
+            type: "Contact",
+            fields: {
+              LastName: "Smith",
+            },
+          });
+
+          try {
+            await dataApiv51.commitUnitOfWork(uow);
+            expect.fail("Promise should have been rejected!");
+          } catch (e) {
+            expect(e.message).to.include(
+              "PROCESSING_HALTED: The transaction was rolled back since another operation in the same transaction failed"
+            );
+            expect(e.message).to.include(
+              "INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY: insufficient access rights on cross-reference id. You can't complete this action because you don't have the required access"
+            );
+          }
+        });
+      });
     });
   });
 

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -778,6 +778,12 @@ describe("DataApi Class", async () => {
       });
 
       describe("multiple errors", async () => {
+        beforeEach(() => {
+          const genRefId = stub(uow, "generateReferenceId");
+          genRefId.onFirstCall().returns("referenceId0");
+          genRefId.onSecondCall().returns("referenceId1");
+        });
+
         it("throws an error containing all error messages", async () => {
           uow.registerCreate({
             type: "Account",
@@ -797,11 +803,9 @@ describe("DataApi Class", async () => {
             await dataApiv51.commitUnitOfWork(uow);
             expect.fail("Promise should have been rejected!");
           } catch (e) {
-            expect(e.message).to.include(
-              "PROCESSING_HALTED: The transaction was rolled back since another operation in the same transaction failed"
-            );
-            expect(e.message).to.include(
-              "INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY: insufficient access rights on cross-reference id. You can't complete this action because you don't have the required access"
+            expect(e.message).to.equal(
+              "PROCESSING_HALTED: The transaction was rolled back since another operation in the same transaction failed\n" +
+                "INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY: insufficient access rights on cross-reference id. You can't complete this action because you don't have the required access"
             );
           }
         });

--- a/test/sdk/data-api.ts
+++ b/test/sdk/data-api.ts
@@ -804,8 +804,8 @@ describe("DataApi Class", async () => {
             expect.fail("Promise should have been rejected!");
           } catch (e) {
             expect(e.message).to.equal(
-              "PROCESSING_HALTED: The transaction was rolled back since another operation in the same transaction failed\n" +
-                "INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY: insufficient access rights on cross-reference id. You can't complete this action because you don't have the required access"
+              "PROCESSING_HALTED: We rolled back the transaction since another operation in the same transaction failed.\n" +
+                "INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY: You can’t complete this action because you don’t have the required access on the cross-reference ID. Contact your Salesforce admin to gain access."
             );
           }
         });


### PR DESCRIPTION
## Summary

`commitUnitOfWork` used `Promise.all` to process composite subrequest responses. When multiple subrequests fail, `Promise.all` short-circuits on the first rejection and silently discards all subsequent errors — callers only ever saw one error.

## Fix

Replace `Promise.all` with `Promise.allSettled` so all subrequests are allowed to settle. Any rejections are collected and thrown together as a single aggregated error (messages joined by `\n`).

## Testing

- **Success:** account, contact, and opportunity composite graph (Salesforce docs example) using `reference_id_account_1`, `reference_id_contact_1`, `reference_id_opportunity_1`
- **Multiple errors:** verifies that `PROCESSING_HALTED` (400) and `INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY` (403) are both present in the thrown error, in order, separated by a newline
- Explicit `generateReferenceId` stubs on all multi-subrequest tests to make WireMock mapping dependencies visible

## Checklist

- [X] I've added or updated unit tests where necessary
- [X] I've added or updated documentation
- [X] I've run `yarn docs` to generate the documentation
- [ ] I've manually tested the functionality in this PR