### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-06-08
+- Release New Latest Version Based off of beta release 1.1.1-beta.1
+
 ## [1.1.1-beta.1] - 2026-06-04
 - Fix `commitUnitOfWork` to surface all subrequest errors. Previously, when multiple subrequests failed, `commitUnitOfWork` only surfaced the first error and discarded subsequent errors.
 - Switch Dependabot to a Mon+Wed cron schedule (11:00 UTC) and standardize PR labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.1.1] - 2026-06-08
-- Release New Latest Version Based off of beta release 1.1.1-beta.1
+- Fix `commitUnitOfWork` to surface all subrequest errors. Previously, when multiple subrequests failed, `commitUnitOfWork` only surfaced the first error and discarded subsequent errors.
+- Switch Dependabot to a Mon+Wed cron schedule (11:00 UTC) and standardize PR labels.
 
 ## [1.1.1-beta.1] - 2026-06-04
 - Fix `commitUnitOfWork` to surface all subrequest errors. Previously, when multiple subrequests failed, `commitUnitOfWork` only surfaced the first error and discarded subsequent errors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heroku/applink",
-  "version": "1.1.1-beta.1",
+  "version": "1.1.1",
   "description": "Applink SDK for Heroku Apps.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps version from `1.1.1-beta.1` to `1.1.1` for stable release
- Updates CHANGELOG.md with the `1.1.1` release entry

## Changes included (from beta)
- Fix `commitUnitOfWork` to surface all subrequest errors using `Promise.allSettled`
- Switch Dependabot to Mon+Wed cron schedule, standardize labels

## Release steps
After merging:
1. `npm publish`
2. `git tag v1.1.1 && git push --tags`