### PR TITLE
Use IP-allowlisted runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   release-please:
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: pub-hk-ubuntu-24.04-ip
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -33,7 +33,7 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-latest
+    runs-on: pub-hk-ubuntu-24.04-ip
     permissions:
       contents: read
       id-token: write
@@ -49,7 +49,7 @@ jobs:
 
   publish-beta:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: pub-hk-ubuntu-24.04-ip
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Switch all jobs in `release.yml` from `ubuntu-latest` to `pub-hk-ubuntu-24.04-ip`
- Fixes IP allowlisting issues that block the release workflow from accessing npm and GitHub APIs

## Context

The `heroku` GitHub org has IP restrictions. Standard `ubuntu-latest` runners use dynamic IPs that aren't on the allowlist. The `pub-hk-ubuntu-24.04-ip` runner pool has static IPs that are pre-approved — same runner used by `heroku-api-plugin` and other heroku packages.

## Test plan

- [ ] Trigger release workflow (push to main) and confirm release-please job succeeds
- [ ] Trigger beta publish via workflow_dispatch and confirm npm publish succeeds