### PR TITLE
Set bootstrap-sha to ignore old conventional commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "55cb6bc",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- Add `bootstrap-sha` to `release-please-config.json` pointing to the latest commit on main (`55cb6bc`)
- Prevents release-please from picking up old `feat:`/`fix:` commits that predate the release automation setup

## Context

release-please was including these old commits in the Release PR:
- `add attachment, color, or url scoped authorizations`
- `don't try and be smart about UA version`
- `ensure x-app-uuid is present when using token`

These are historical commits that were already released manually. `bootstrap-sha` tells release-please to only consider commits after the specified SHA.

## Test plan

- [ ] Merge and verify the release-please PR no longer includes those old commits