### PR TITLE
Fix bootstrap-sha to use full commit SHA

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "55cb6bc",
+  "bootstrap-sha": "55cb6bc0dd325be096c7e80b1380ad50ded851a0",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- Fix `bootstrap-sha` in `release-please-config.json` to use the full 40-character SHA
- Short SHA (`55cb6bc`) doesn't work — release-please requires the full form

## Context

After merging PR #108, release-please still picked up old commits because it was comparing the abbreviated SHA against full SHAs in git history and not finding a match.

## Test plan

- [ ] Merge and verify release-please PR updates to exclude old conventional commits