### PR TITLE
make dependabot compatible with release-please

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 11 * * MON,WED"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
     groups:
       production-dependencies:
         dependency-type: "production"
@@ -45,6 +48,8 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 11 * * MON,WED"
+    commit-message:
+      prefix: "chore"
     labels:
       - "edit-on-call"
       - "dependencies"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,30 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: pub-hk-ubuntu-24.04-ip
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            ci
+            refactor
+            perf
+            test
+            revert
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: "PR title must have a subject after the type prefix"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,11 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "55cb6bc",
   "changelog-sections": [
-    {"type": "feat", "section": "Features"},
-    {"type": "fix", "section": "Bug Fixes"},
-    {"type": "chore", "section": "Dependency Updates"},
-    {"type": "docs", "section": "Documentation", "hidden": true},
-    {"type": "ci", "section": "CI", "hidden": true}
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "section": "Dependency Updates" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "ci", "section": "CI", "hidden": true }
   ],
   "packages": {
     ".": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "55cb6bc",
+  "changelog-sections": [
+    {"type": "feat", "section": "Features"},
+    {"type": "fix", "section": "Bug Fixes"},
+    {"type": "chore", "section": "Dependency Updates"},
+    {"type": "docs", "section": "Documentation", "hidden": true},
+    {"type": "ci", "section": "CI", "hidden": true}
+  ],
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- Add `commit-message.prefix: "chore"` to both dependabot package ecosystems (npm + github-actions)
- Add `changelog-sections` to release-please config to categorize dependency updates

## How it works

**Before:** Dependabot commits like `Bump mocha from 11.7.5 to 11.8.0` — release-please ignores these (no conventional commit prefix), so they never appear in changelogs or trigger version bumps.

**After:** Dependabot commits become `chore: Bump mocha from 11.7.5 to 11.8.0` — release-please picks them up and groups them under a "Dependency Updates" section in the changelog. Since `chore` doesn't trigger a version bump on its own, these accumulate in the Release PR until a `feat:` or `fix:` commit triggers a release.

## Changelog sections

| Commit prefix | Section | Visible |
|---------------|---------|---------|
| `feat:` | Features | Yes |
| `fix:` | Bug Fixes | Yes |
| `chore:` | Dependency Updates | Yes |
| `docs:` | Documentation | Hidden |
| `ci:` | CI | Hidden |

## Test plan

- [ ] Verify next dependabot PR uses `chore:` prefix in commit message
- [ ] Verify release-please Release PR includes dependency updates section