### PR TITLE
chore: fix CVE-2026-9277 shell-quote command injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "xml2js": "0.5.0",
     "tough-cookie": "4.1.4",
     "serialize-javascript": "7.0.4",
-    "cross-spawn": "7.0.6"
+    "cross-spawn": "7.0.6",
+    "shell-quote": "1.8.4"
   },
   "optionalDependencies": {
     "fsevents": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3330,10 +3330,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@1.8.3, shell-quote@1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 signal-exit@^3.0.2:
   version "3.0.7"


### PR DESCRIPTION
## Summary
- Adds `shell-quote` 1.8.4 to yarn resolutions to fix critical command injection vulnerability ([GHSA-w7jw-789q-3m8p](https://github.com/ljharb/shell-quote/security/advisories/GHSA-w7jw-789q-3m8p))
- `shell-quote` <= 1.8.3's `quote()` function fails to escape newlines in object token `.op` values, allowing shell command injection
- `shell-quote` is a transitive dev dependency (via `concurrently`) — **zero impact on published package consumers**

## Context
Resolves https://github.com/heroku/heroku-applink-nodejs/security/dependabot/53

CVSS v4: 9.2 (Critical)

## Test plan
- [x] CI passes (yarn install resolves shell-quote to 1.8.4)
- [x] `yarn why shell-quote` shows 1.8.4