### PR TITLE
chore: fix CVE-2026-34043 serialize-javascript CPU exhaustion DoS

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "minimist": "1.2.6",
     "xml2js": "0.5.0",
     "tough-cookie": "4.1.4",
-    "serialize-javascript": "7.0.4",
+    "serialize-javascript": "7.0.5",
     "cross-spawn": "7.0.6"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,10 +3303,10 @@ sequin@*:
   resolved "https://registry.yarnpkg.com/sequin/-/sequin-0.1.1.tgz#5c2d389d66a383734eaafbc45edeb2c1cb1be701"
   integrity sha512-hJWMZRwP75ocoBM+1/YaCsvS0j5MTPeBHJkS2/wruehl9xwtX30HlDF1Gt6UZ8HHHY8SJa2/IL+jo+JJCd59rA==
 
-serialize-javascript@7.0.4, serialize-javascript@^6.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.4.tgz#c517735bd5b7631dd1fc191ee19cbb713ff8e05c"
-  integrity sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==
+serialize-javascript@7.0.5, serialize-javascript@^6.0.2:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary
- Bumps `serialize-javascript` yarn resolution from 7.0.4 to 7.0.5 to fix CPU exhaustion DoS vulnerability ([GHSA-qj8w-gfj5-8c6v](https://github.com/yahoo/serialize-javascript/security/advisories/GHSA-qj8w-gfj5-8c6v))
- Crafted array-like objects with large `length` properties caused `serialize()` to enter an infinite loop due to `instanceof Array` checks; fixed by using `Array.isArray()` and `Object.keys()` for sparse array detection
- `serialize-javascript` is a transitive dev dependency (via `mocha`) — **zero impact on published package consumers**

## Context
Resolves https://github.com/heroku/heroku-applink-nodejs/security/dependabot/51

CVSS v3: 5.9 (Medium)

Note: We previously pinned serialize-javascript to 7.0.4 for the RCE fix (GHSA-3fjq-93jr-5rvc). This bumps that existing pin to also cover the newer DoS advisory.

## Test plan
- [ ] CI passes (yarn install resolves serialize-javascript to 7.0.5)
- [ ] `mocha --version` loads successfully with updated dependency