### PR TITLE
ci: add versioning: prerelease to next config

### DIFF
--- a/release-please-config-next.json
+++ b/release-please-config-next.json
@@ -12,6 +12,7 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
+      "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta"
     }


### PR DESCRIPTION
## Summary

Without `versioning: prerelease`, release-please's default versioning strategy strips the `-beta.N` suffix even when `prerelease: true` and `prerelease-type: beta` are set. The first release PR opened on `next` (#127, now closed) bumped the version to `2.0.0` instead of `2.0.0-beta.0` — which would have published as a flat stable version on npm.

This adds the missing `versioning: prerelease` to `release-please-config-next.json` so the prerelease versioning strategy is actually selected.

## Follow-up

After this merges, we need to check PR that gets created, and if everything looks okay, merge that PR and check the release attempt. 

## Reference

- release-please source: [versioning-strategies/prerelease.ts](https://github.com/googleapis/release-please/blob/main/src/versioning-strategies/prerelease.ts) — `prerelease: true` only takes effect inside `PrereleaseVersioningStrategy`.
- [versioning-strategy-factory.ts](https://github.com/googleapis/release-please/blob/main/src/factories/versioning-strategy-factory.ts) — `versioning: "prerelease"` selects that strategy.

## Test plan

- [ ] Merge → forward-merge into `next` → verify release PR on `next` is titled `chore(next): release 2.0.0-beta.0`
- [ ] Verify the new release PR's diff bumps `package.json` version to `2.0.0-beta.0` (not `2.0.0`)