### PR TITLE
ci: pin Node 26.x to 26.3.0 (dodge http.Agent CVE-2026-48931 regression)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [26.x, 24.x, 22.x]
+        # Node 26.x is pinned to 26.3.0; 26.3.1's CVE-2026-48931 http.Agent
+        # patch hangs node-fetch@2.x keep-alive sockets. Unpin once
+        # https://github.com/nodejs/node/issues/63989 is resolved.
+        version: [26.3.0, 24.x, 22.x]
         os: [ubuntu-latest, macos-14-large, windows-latest]
     name: Node ${{ matrix.version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Node 26.x CI has been failing on `main` since the @salesforce/core bump in #132 (2026-06-22). Investigation showed the regression is **not** code-related — it's that `setup-node@v6` started resolving `node-version: 26.x` to **26.3.0 → 26.3.1** between the last green build (06-16) and the next run (06-22). 26.3.1's CVE-2026-48931 patch for `http.Agent` interacts badly with `node-fetch@2.x`'s keep-alive socket pool: every idle pooled socket gets a `freeSocketDataGuard` listener + `resume()`, which causes the socket to be destroyed whenever node-fetch hasn't fully drained the response body. The next request through node-fetch then hangs trying to reuse the destroyed socket, until mocha's per-test timeout fires (~2 min/test).

jsforce uses `node-fetch@2.7.0` internally for all bulk-api / data-api calls, so every wiremock-backed test in `test/sdk/bulk-api.test.ts` and `test/sdk/data-api.ts` was hanging.

Related upstream tracker: [nodejs/node#63989](https://github.com/nodejs/node/issues/63989) reports the same CVE-2026-48931 patch causing a different symptom (`ERR_STREAM_PREMATURE_CLOSE` on HTTPS keep-alive to googleapis.com) on **v24.17.0**. The fix was backported across 22/24/26 release lines, so it's the same root cause but a distinct failure mode from ours. I have not yet found an upstream issue specifically filed for the hang-on-localhost-HTTP variant we hit.

## Fix

Pin the matrix's Node 26.x entry to **26.3.0** until the upstream regression is resolved. 24.x and 22.x are left as floating minors — they passed our tests in the same affected window, but per upstream the same patch was backported, so we may need to pin them too if they start failing.

## Test plan

- [ ] CI is green on this PR (all 9 Node × OS matrix entries pass)
- [ ] Follow nodejs/node#63989 (and watch for a 26.x-specific issue) and remove the pin when fixed
