### PR TITLE
docs: set `GUSINFO` team and product tag in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 #ECCN:Open Source
-#GUSINFO:Open Source,Open Source Workflow
+#GUSINFO:Heroku EDIT,Heroku AppLink
 # Owned by the Heroku AppLink team
 * @heroku/heroku-applink


### PR DESCRIPTION
The `#GUSINFO:` line in `CODEOWNERS` uses the placeholder `Open Source,Open Source Workflow` rather than a real team/product tag. This change sets it to `Heroku EDIT,Heroku AppLink`, matching the `@heroku/heroku-applink` owner team noted in the file.

GUS-W-23525396.